### PR TITLE
Implement goodix5xx api

### DIFF
--- a/libfprint/drivers/goodixtls/goodix511.c
+++ b/libfprint/drivers/goodixtls/goodix511.c
@@ -68,10 +68,10 @@ struct _FpiDeviceGoodixTls511
 };
 
 /*G_DECLARE_FINAL_TYPE (FpiDeviceGoodixTls511, fpi_device_goodixtls511, FPI,*/
-                      /*DEVICE_GOODIXTLS511, FpiDeviceGoodixTls);*/
+/*DEVICE_GOODIXTLS511, FpiDeviceGoodixTls);*/
 
 /*G_DEFINE_TYPE (FpiDeviceGoodixTls511, fpi_device_goodixtls511,*/
-               /*FPI_TYPE_DEVICE_GOODIXTLS);*/
+/*FPI_TYPE_DEVICE_GOODIXTLS);*/
 
 G_DECLARE_FINAL_TYPE (FpiDeviceGoodixTls511, fpi_device_goodixtls511, FPI,
                       DEVICE_GOODIXTLS511, FpiDeviceGoodixTls5xx);
@@ -94,45 +94,6 @@ enum activate_states {
   ACTIVATE_SET_POWERDOWN_SCAN_FREQUENCY,
   ACTIVATE_NUM_STATES,
 };
-
-#ifdef GOODIX511_DUMP_FRAMES
-static gboolean
-save_image_to_pgm (FpImage *img, const char *path)
-{
-  FILE *fd = fopen (path, "w");
-  size_t write_size;
-  const guchar *data = fp_image_get_data (img, &write_size);
-  int r;
-
-  if (!fd)
-    {
-      g_warning ("could not open '%s' for writing: %d", path, errno);
-      return FALSE;
-    }
-
-  r = fprintf (fd, "P5 %d %d 255\n", fp_image_get_width (img),
-               fp_image_get_height (img));
-  if (r < 0)
-    {
-      fclose (fd);
-      g_critical ("pgm header write failed, error %d", r);
-      return FALSE;
-    }
-
-  r = fwrite (data, 1, write_size, fd);
-  if (r < write_size)
-    {
-      fclose (fd);
-      g_critical ("short write (%d)", r);
-      return FALSE;
-    }
-
-  fclose (fd);
-  g_debug ("written to '%s'", path);
-
-  return TRUE;
-}
-#endif
 
 static void
 check_none (FpDevice *dev, gpointer user_data, GError *error)
@@ -686,12 +647,10 @@ dev_activate (FpImageDevice *img_dev)
 static void
 dev_change_state (FpImageDevice *img_dev, FpiImageDeviceState state)
 {
-  FpiDeviceGoodixTls511 *self = FPI_DEVICE_GOODIXTLS511 (img_dev);
-
   G_DEBUG_HERE ();
 
   if (state == FPI_IMAGE_DEVICE_STATE_AWAIT_FINGER_ON)
-    goodixtls5xx_scan_start(FP_DEVICE(img_dev));
+    goodixtls5xx_scan_start (FPI_DEVICE_GOODIXTLS5XX (img_dev));
 }
 
 static void
@@ -719,16 +678,22 @@ fpi_device_goodixtls511_init (FpiDeviceGoodixTls511 *self)
 {
   self->frames = g_slist_alloc ();
 }
-static GoodixTls5xxMcuConfig get_mcu_config() {
+static GoodixTls5xxMcuConfig
+get_mcu_config ()
+{
   GoodixTls5xxMcuConfig cfg;
+
   cfg.free_fn = NULL;
   cfg.data = fdt_switch_state_mode;
-  cfg.data_len = sizeof(fdt_switch_state_mode);
+  cfg.data_len = sizeof (fdt_switch_state_mode);
   return cfg;
 }
 
-static FpImage* crop_frame(guint8* frame) {
-  FpImage* img = fp_image_new(GOODIX511_WIDTH, GOODIX511_HEIGHT);
+static FpImage *
+crop_frame (guint8 * frame)
+{
+  FpImage * img = fp_image_new (GOODIX511_WIDTH, GOODIX511_HEIGHT);
+
   img->flags |= FPI_IMAGE_PARTIAL;
   for (int y = 0; y != GOODIX511_HEIGHT; ++y)
     {
@@ -738,7 +703,7 @@ static FpImage* crop_frame(guint8* frame) {
           img->data[x + y * GOODIX511_WIDTH] = frame[idx];
         }
     }
-    return img;
+  return img;
 }
 
 static void

--- a/libfprint/drivers/goodixtls/goodix511.c
+++ b/libfprint/drivers/goodixtls/goodix511.c
@@ -299,7 +299,7 @@ otp_write_run (FpiSsm *ssm, FpDevice *dev)
     }
 
   goodix_send_write_sensor_register (
-    dev, otp_write_addrs[fpi_ssm_get_cur_state (ssm)], data, check_none,
+    dev, otp_write_addrs[fpi_ssm_get_cur_state (ssm)], data, goodixtls5xx_check_none,
     ssm);
   if (fpi_ssm_get_cur_state (ssm) == OTP_WRITE_NUM - 1)
     free (self->otp);
@@ -337,32 +337,32 @@ activate_run_state (FpiSsm *ssm, FpDevice *dev)
       // Nop seems to clear the previous command buffer. But we are
       // unable to do so.
       goodix_start_read_loop (dev);
-      goodix_send_nop (dev, check_none, ssm);
+      goodix_send_nop (dev, goodixtls5xx_check_none, ssm);
       break;
 
     case ACTIVATE_ENABLE_CHIP:
-      goodix_send_enable_chip (dev, TRUE, check_none, ssm);
+      goodix_send_enable_chip (dev, TRUE, goodixtls5xx_check_none, ssm);
       break;
 
     case ACTIVATE_NOP:
-      goodix_send_nop (dev, check_none, ssm);
+      goodix_send_nop (dev, goodixtls5xx_check_none, ssm);
       break;
 
     case ACTIVATE_CHECK_FW_VER:
-      goodix_send_query_firmware_version (dev, check_firmware_version, ssm);
+      goodix_send_query_firmware_version (dev, goodixtls5xx_check_firmware_version, ssm);
       break;
 
     case ACTIVATE_CHECK_PSK:
       goodix_send_preset_psk_read (dev, GOODIX_511_PSK_FLAGS, 0,
-                                   check_preset_psk_read, ssm);
+                                   goodixtls5xx_check_preset_psk_read, ssm);
       break;
 
     case ACTIVATE_RESET:
-      goodix_send_reset (dev, TRUE, 20, check_reset, ssm);
+      goodix_send_reset (dev, TRUE, 20, goodixtls5xx_check_reset, ssm);
       break;
 
     case ACTIVATE_SET_MCU_IDLE:
-      goodix_send_mcu_switch_to_idle_mode (dev, 20, check_idle, ssm);
+      goodix_send_mcu_switch_to_idle_mode (dev, 20, goodixtls5xx_check_idle, ssm);
       break;
 
     case ACTIVATE_READ_ODP:
@@ -372,28 +372,14 @@ activate_run_state (FpiSsm *ssm, FpDevice *dev)
     case ACTIVATE_UPLOAD_MCU_CONFIG:
       goodix_send_upload_config_mcu (dev, goodix_511_config,
                                      sizeof (goodix_511_config), NULL,
-                                     check_config_upload, ssm);
+                                     goodixtls5xx_check_config_upload, ssm);
       break;
 
     case ACTIVATE_SET_POWERDOWN_SCAN_FREQUENCY:
       goodix_send_set_powerdown_scan_frequency (
-        dev, 100, check_powerdown_scan_freq, ssm);
+        dev, 100, goodixtls5xx_check_powerdown_scan_freq, ssm);
       break;
     }
-}
-
-static void
-tls_activation_complete (FpDevice *dev, gpointer user_data,
-                         GError *error)
-{
-  if (error)
-    {
-      fp_err ("failed to complete tls activation: %s", error->message);
-      return;
-    }
-  FpImageDevice *image_dev = FP_IMAGE_DEVICE (dev);
-
-  fpi_image_device_activate_complete (image_dev, error);
 }
 
 static void
@@ -402,7 +388,7 @@ activate_complete (FpiSsm *ssm, FpDevice *dev, GError *error)
   G_DEBUG_HERE ();
   if (!error)
     {
-      goodix_tls_init (dev, tls_activation_complete, NULL);
+      goodixtls5xx_init_tls (dev);
     }
   else
     {
@@ -417,172 +403,6 @@ activate_complete (FpiSsm *ssm, FpDevice *dev, GError *error)
 // -----------------------------------------------------------------------------
 
 // ---- SCAN SECTION START ----
-
-enum SCAN_STAGES {
-  SCAN_STAGE_QUERY_MCU,
-  SCAN_STAGE_SWITCH_TO_FDT_MODE,
-  SCAN_STAGE_SWITCH_TO_FDT_DOWN,
-  SCAN_STAGE_GET_IMG,
-  SCAN_STAGE_SWITCH_TO_FTD_UP,
-  SCAN_STAGE_SWITCH_TO_FTD_DONE,
-
-  SCAN_STAGE_NUM,
-};
-
-static void
-check_none_cmd (FpDevice *dev, guint8 *data, guint16 len,
-                gpointer ssm, GError *err)
-{
-  if (err)
-    {
-      fpi_ssm_mark_failed (ssm, err);
-      return;
-    }
-  fpi_ssm_next_state (ssm);
-}
-
-static void
-decode_frame (Goodix511Pix  frame[GOODIX511_FRAME_SIZE],
-              const guint8 *raw_frame)
-{
-
-  Goodix511Pix uncropped[GOODIX511_SCAN_WIDTH * GOODIX511_HEIGHT];
-  Goodix511Pix *pix = uncropped;
-
-  for (int i = 8; i != GOODIX511_RAW_FRAME_SIZE - 5; i += 6)
-    {
-      const guint8 *chunk = raw_frame + i;
-      *pix++ = ((chunk[0] & 0xf) << 8) + chunk[1];
-      *pix++ = (chunk[3] << 4) + (chunk[0] >> 4);
-      *pix++ = ((chunk[5] & 0xf) << 8) + chunk[2];
-      *pix++ = (chunk[4] << 4) + (chunk[5] >> 4);
-    }
-  for (int y = 0; y != GOODIX511_HEIGHT; ++y)
-    {
-      for (int x = 0; x != GOODIX511_WIDTH; ++x)
-        {
-          const int idx = x + y * GOODIX511_SCAN_WIDTH;
-          frame[x + y * GOODIX511_WIDTH] = uncropped[idx];
-        }
-    }
-}
-
-/**
- * @brief Squashes the 12 bit pixels of a raw frame into the 4 bit pixels used
- * by libfprint.
- * @details Borrowed from the elan driver. We reduce frames to
- * within the max and min.
- *
- * @param frame
- * @param squashed
- */
-static void
-squash_frame_linear (Goodix511Pix *frame, guint8 *squashed)
-{
-  Goodix511Pix min = 0xffff;
-  Goodix511Pix max = 0;
-
-  for (int i = 0; i != GOODIX511_FRAME_SIZE; ++i)
-    {
-      const Goodix511Pix pix = frame[i];
-      if (pix < min)
-        min = pix;
-      if (pix > max)
-        max = pix;
-    }
-
-  for (int i = 0; i != GOODIX511_FRAME_SIZE; ++i)
-    {
-      const Goodix511Pix pix = frame[i];
-      if (pix - min == 0 || max - min == 0)
-        squashed[i] = 0;
-      else
-        squashed[i] = (pix - min) * 0xff / (max - min);
-    }
-}
-
-typedef struct _frame_processing_info
-{
-  FpiDeviceGoodixTls511 * dev;
-  GSList               ** frames;
-
-} frame_processing_info;
-
-static void
-process_frame (Goodix511Pix *raw_frame, frame_processing_info *info)
-{
-  unsigned char * frame = g_malloc (GOODIX511_FRAME_SIZE);
-
-  squash_frame_linear (raw_frame, frame);
-
-  *(info->frames) = g_slist_append (*(info->frames), frame);
-}
-
-static void
-save_frame (FpiDeviceGoodixTls511 * self, guint8 * raw)
-{
-  Goodix511Pix *frame = malloc (GOODIX511_FRAME_SIZE * sizeof (Goodix511Pix));
-
-  decode_frame (frame, raw);
-  self->frames = g_slist_append (self->frames, frame);
-}
-
-static void
-scan_on_read_img (FpDevice *dev, guint8 *data, guint16 len,
-                  gpointer ssm, GError *err)
-{
-  if (err)
-    {
-      fpi_ssm_mark_failed (ssm, err);
-      return;
-    }
-
-  FpiDeviceGoodixTls511 *self = FPI_DEVICE_GOODIXTLS511 (dev);
-  save_frame (self, data);
-  if (g_slist_length (self->frames) <= GOODIX511_CAP_FRAMES)
-    {
-      fpi_ssm_jump_to_state (ssm, SCAN_STAGE_SWITCH_TO_FDT_MODE);
-    }
-  else
-    {
-      GSList *raw_frames = g_slist_nth (self->frames, 1);
-
-      FpImageDevice * img_dev = FP_IMAGE_DEVICE (dev);
-
-      GSList *frames = NULL;
-      frame_processing_info pinfo = {.dev = self, .frames = &frames};
-
-      //process_frame(g_slist_nth_data(raw_frames, 0), &pinfo);
-      g_slist_foreach (raw_frames, (GFunc) process_frame, &pinfo);
-      // frames = g_slist_reverse(frames);
-
-      //fpi_do_movement_estimation(&assembly_ctx, frames);
-      FpImage * img = fp_image_new (GOODIX511_WIDTH, GOODIX511_HEIGHT);
-      memcpy (img->data, g_slist_nth_data (frames, 0), GOODIX511_FRAME_SIZE);
-      //FpImage* img = fpi_assemble_frames(&assembly_ctx, frames);
-      img->flags |= FPI_IMAGE_PARTIAL;
-#ifdef GOODIX511_DUMP_FRAMES
-      char buff[2014];
-      snprintf (buff, sizeof (buff), "cut33/f_%d.pgm",
-                g_slist_length (self->frames));
-      save_image_to_pgm (img, buff);
-#endif
-
-      g_slist_free_full (frames, g_free);
-      g_slist_free_full (self->frames, g_free);
-      self->frames = g_slist_alloc ();
-
-      fpi_image_device_image_captured (img_dev, img);
-
-      fpi_ssm_next_state (ssm);
-    }
-}
-
-static void
-scan_get_img (FpDevice * dev, FpiSsm * ssm)
-{
-  goodix_tls_read_image (dev, scan_on_read_img, ssm);
-}
 
 const guint8 fdt_switch_state_mode[] = {
   0x01,
@@ -606,36 +426,6 @@ const guint8 fdt_switch_state_mode[] = {
 // ---- DEV SECTION START ----
 
 static void
-dev_init (FpImageDevice *img_dev)
-{
-  FpDevice *dev = FP_DEVICE (img_dev);
-  GError *error = NULL;
-
-  if (goodix_dev_init (dev, &error))
-    {
-      fpi_image_device_open_complete (img_dev, error);
-      return;
-    }
-
-  fpi_image_device_open_complete (img_dev, NULL);
-}
-
-static void
-dev_deinit (FpImageDevice *img_dev)
-{
-  FpDevice *dev = FP_DEVICE (img_dev);
-  GError *error = NULL;
-
-  if (goodix_dev_deinit (dev, &error))
-    {
-      fpi_image_device_close_complete (img_dev, error);
-      return;
-    }
-
-  fpi_image_device_close_complete (img_dev, NULL);
-}
-
-static void
 dev_activate (FpImageDevice *img_dev)
 {
   FpDevice *dev = FP_DEVICE (img_dev);
@@ -645,30 +435,8 @@ dev_activate (FpImageDevice *img_dev)
 }
 
 static void
-dev_change_state (FpImageDevice *img_dev, FpiImageDeviceState state)
-{
-  G_DEBUG_HERE ();
-
-  if (state == FPI_IMAGE_DEVICE_STATE_AWAIT_FINGER_ON)
-    goodixtls5xx_scan_start (FPI_DEVICE_GOODIXTLS5XX (img_dev));
-}
-
-static void
 goodix511_reset_state (FpiDeviceGoodixTls511 *self)
 {
-}
-
-static void
-dev_deactivate (FpImageDevice *img_dev)
-{
-  FpDevice *dev = FP_DEVICE (img_dev);
-
-  goodix_reset_state (dev);
-  GError *error = NULL;
-
-  goodix_shutdown_tls (dev, &error);
-  goodix511_reset_state (FPI_DEVICE_GOODIXTLS511 (img_dev));
-  fpi_image_device_deactivate_complete (img_dev, error);
 }
 
 // ---- DEV SECTION END ----
@@ -718,6 +486,11 @@ fpi_device_goodixtls511_class_init (FpiDeviceGoodixTls511Class * class)
   xx_cls->process_frame = crop_frame;
   xx_cls->scan_height = GOODIX511_HEIGHT;
   xx_cls->scan_width = GOODIX511_SCAN_WIDTH;
+  xx_cls->psk = goodix_511_psk_0;
+  xx_cls->psk_flags = GOODIX_511_PSK_FLAGS;
+  xx_cls->psk_len = sizeof (goodix_511_psk_0);
+  xx_cls->firmware_version = GOODIX_511_FIRMWARE_VERSION;
+  xx_cls->reset_number = GOODIX_511_RESET_NUMBER;
 
   gx_class->interface = GOODIX_511_INTERFACE;
   gx_class->ep_in = GOODIX_511_EP_IN;
@@ -737,11 +510,7 @@ fpi_device_goodixtls511_class_init (FpiDeviceGoodixTls511Class * class)
   img_dev_class->img_width = GOODIX511_WIDTH;
   img_dev_class->img_height = GOODIX511_HEIGHT;
 
-  img_dev_class->img_open = dev_init;
-  img_dev_class->img_close = dev_deinit;
   img_dev_class->activate = dev_activate;
-  img_dev_class->change_state = dev_change_state;
-  img_dev_class->deactivate = dev_deactivate;
 
   fpi_device_class_auto_initialize_features (dev_class);
 }

--- a/libfprint/drivers/goodixtls/goodix5xx.c
+++ b/libfprint/drivers/goodixtls/goodix5xx.c
@@ -1,0 +1,183 @@
+// Goodix Tls driver for libfprint
+
+// Copyright (C) 2021 Alexander Meiler <alex.meiler@protonmail.com>
+// Copyright (C) 2021 Matthieu CHARETTE <matthieu.charette@gmail.com>
+// Copyright (C) 2021 Natasha England-Elbro <ashenglandelbro@protonmail.com>
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#include "drivers/goodixtls/goodix5xx.h"
+#include "drivers_api.h"
+#include "goodix.h"
+
+
+typedef struct
+{
+
+} FpiDeviceGoodixTlsPrivate;
+
+G_DEFINE_ABSTRACT_TYPE_WITH_PRIVATE (FpiDeviceGoodixTls, fpi_device_goodixtls5xx, FPI_TYPE_DEVICE_GOODIXTLS5XX)
+
+#pragma region "constants"
+
+enum SCAN_STAGES {
+  SCAN_STAGE_QUERY_MCU,
+  SCAN_STAGE_SWITCH_TO_FDT_MODE,
+  SCAN_STAGE_SWITCH_TO_FDT_DOWN,
+  SCAN_STAGE_GET_IMG,
+  SCAN_STAGE_SWITCH_TO_FTD_UP,
+  SCAN_STAGE_SWITCH_TO_FTD_DONE,
+
+  SCAN_STAGE_NUM,
+};
+
+#pragma endregion
+
+#pragma region "check callbacks"
+
+static void
+check_none_cmd (FpDevice *dev, guint8 *data, guint16 len,
+                gpointer ssm, GError *err)
+{
+  if (err)
+    {
+      fpi_ssm_mark_failed (ssm, err);
+      return;
+    }
+  fpi_ssm_next_state (ssm);
+}
+
+#pragma endregion
+
+#pragma region "scan"
+
+static void
+query_mcu_state_cb (FpDevice * dev, guchar * mcu_state, guint16 len,
+                    gpointer ssm, GError * error)
+{
+  if (error)
+    {
+      fpi_ssm_mark_failed (ssm, error);
+      return;
+    }
+  fpi_ssm_next_state (ssm);
+}
+
+static void
+scan_on_read_img (FpDevice *dev, guint8 *data, guint16 len,
+                  gpointer ssm, GError *err)
+{
+  if (err)
+    {
+      fpi_ssm_mark_failed (ssm, err);
+      return;
+    }
+
+  FpiDeviceGoodixTls5xxClass *cls = FPI_DEVICE_GOODIXTLS5XX_GET_CLASS (dev);
+  FpImageDevice * img_dev = FP_IMAGE_DEVICE (dev);
+
+  GoodixTls5xxPix * raw_frame = malloc ((cls->scan_width * cls->scan_height) * sizeof (GoodixTls5xxPix));
+  goodixtls5xx_decode_frame (raw_frame, cls->scan_height * cls->scan_width, data);
+  FpImage * img = cls->process_frame (raw_frame);
+
+  fpi_image_device_image_captured (img_dev, img);
+
+  fpi_ssm_next_state (ssm);
+}
+
+static void
+scan_get_img (FpDevice * dev, FpiSsm * ssm)
+{
+  goodix_tls_read_image (dev, scan_on_read_img, ssm);
+}
+
+static void
+send_switch_mode (FpDevice * dev, gpointer ssm, void (*mode_switch)(FpDevice *, const guint8 *, guint16, GDestroyNotify, GoodixDefaultCallback, gpointer))
+{
+  FpiDeviceGoodixTls5xxClass *cls = FPI_DEVICE_GOODIXTLS5XX_GET_CLASS (dev);
+  GoodixTls5xxMcuConfig cfg = cls->get_mcu_cfg ();
+
+  mode_switch (dev, cfg.data, cfg.data_len, cfg.free_fn, check_none_cmd, ssm);
+}
+
+static void
+scan_run_state (FpiSsm * ssm, FpDevice * dev)
+{
+  FpImageDevice *img_dev = FP_IMAGE_DEVICE (dev);
+  FpiDeviceGoodixTls5xxClass *cls = FPI_DEVICE_GOODIXTLS5XX_GET_CLASS (dev);
+
+  switch (fpi_ssm_get_cur_state (ssm))
+    {
+    case SCAN_STAGE_QUERY_MCU:
+      goodix_send_query_mcu_state (dev, query_mcu_state_cb, ssm);
+      break;
+
+    case SCAN_STAGE_SWITCH_TO_FDT_MODE:
+      send_switch_mode (dev, ssm, goodix_send_mcu_switch_to_fdt_mode);
+      break;
+
+    case SCAN_STAGE_SWITCH_TO_FDT_DOWN:
+      send_switch_mode (dev, ssm, goodix_send_mcu_switch_to_fdt_down );
+      break;
+
+    case SCAN_STAGE_GET_IMG:
+      fpi_image_device_report_finger_status (img_dev, TRUE);
+      scan_get_img (dev, ssm);
+      break;
+
+    case SCAN_STAGE_SWITCH_TO_FTD_UP:
+      send_switch_mode (dev, ssm, goodix_send_mcu_switch_to_fdt_up );
+      break;
+
+    case SCAN_STAGE_SWITCH_TO_FTD_DONE:
+      fpi_image_device_report_finger_status (img_dev, FALSE);
+      break;
+    }
+}
+
+static void
+scan_complete (FpiSsm *ssm, FpDevice *dev, GError *error)
+{
+  if (error)
+    {
+      fp_err ("failed to scan: %s (code: %d)", error->message, error->code);
+      fpi_image_device_session_error (FP_IMAGE_DEVICE (dev), error);
+      return;
+    }
+  fp_dbg ("finished scan");
+}
+
+#pragma endregion
+
+void
+goodixtls5xx_scan_start (FpDevice * dev)
+{
+  fpi_ssm_start (fpi_ssm_new (dev, scan_run_state, SCAN_STAGE_NUM), scan_complete);
+}
+
+void
+goodixtls5xx_decode_frame (GoodixTls5xxPix * frame, guint32 frame_size, const guint8 *raw_frame)
+{
+  GoodixTls5xxPix *pix = frame;
+
+  for (int i = 8; i != frame_size - 5; i += 6)
+    {
+      const guint8 *chunk = raw_frame + i;
+      *pix++ = ((chunk[0] & 0xf) << 8) + chunk[1];
+      *pix++ = (chunk[3] << 4) + (chunk[0] >> 4);
+      *pix++ = ((chunk[5] & 0xf) << 8) + chunk[2];
+      *pix++ = (chunk[4] << 4) + (chunk[5] >> 4);
+    }
+}

--- a/libfprint/drivers/goodixtls/goodix5xx.h
+++ b/libfprint/drivers/goodixtls/goodix5xx.h
@@ -27,6 +27,21 @@
 
 G_DECLARE_DERIVABLE_TYPE (FpiDeviceGoodixTls5xx, fpi_device_goodixtls5xx, FPI, DEVICE_GOODIXTLS5XX, FpiDeviceGoodixTls);
 
+/**
+ * @brief API for the common parts of communication between the goodixtls 5xx device
+ * @details This API is designed to make it easier to write and maintain
+ * drivers for the goodixtls 5xx (usb) devices. For an example out goodix511.c.
+ *
+ * @par The bare minimum needed is to provide get_mcu_cfg and process_frame to
+ * FpiDeviceGoodixTls5xxClass and activate to FpImageDeviceClass (activate
+ * varies from device to device)
+ *
+ * @par There are also quite a few helper functions in the goodixtls5xx_*
+ * namespace, the check functions expect a state machine as the user data and
+ * will advance it or mark it as failed as appropriate
+ * @struct FpiDeviceGoodixTls5xx
+ *
+ */
 
 typedef guint16 GoodixTls5xxPix;
 

--- a/libfprint/drivers/goodixtls/goodix5xx.h
+++ b/libfprint/drivers/goodixtls/goodix5xx.h
@@ -53,12 +53,12 @@ struct _FpiDeviceGoodixTls5xxClass
 {
   FpiDeviceGoodixTlsClass    parent;
 
-  GoodixTls5xxGetMcuFn       get_mcu_cfg;
-  GoodixTls5xxProcessFrameFn process_frame;
-  GoodixTls5xxResetStateFn   reset_state;
+  GoodixTls5xxGetMcuFn       get_mcu_cfg; ///< provide the mcu config before fdt commands
+  GoodixTls5xxProcessFrameFn process_frame; ///< process a frame after it is decoded (e.g. crop it)
+  GoodixTls5xxResetStateFn   reset_state; ///< callback to reset the state, may be NULL
 
-  guint16                    scan_width;
-  guint16                    scan_height;
+  guint16                    scan_width; ///< width of the raw scanner image
+  guint16                    scan_height; ///< height of the raw scanner image
 
   const char               * firmware_version; ///< only needed if goodixtls5xx_check_firmware_version() is used
 
@@ -70,18 +70,48 @@ struct _FpiDeviceGoodixTls5xxClass
   int            reset_number; ///< only needed if goodixtls5xx_check_reset() is used
 };
 
+/**
+ * @brief Check the reply to a reset command
+ *
+ * @param dev
+ * @param success
+ * @param number
+ * @param user_data
+ * @param error
+ */
 void goodixtls5xx_check_reset (FpDevice *dev,
                                gboolean  success,
                                guint16   number,
                                gpointer  user_data,
                                GError   *error);
 
+/**
+ * @brief Check the reply to a firmware version query matches configured firmware
+ * @note Requires firmware_version field to be set
+ *
+ * @param dev
+ * @param firmware
+ * @param user_data
+ * @param error
+ */
 void goodixtls5xx_check_firmware_version (FpDevice *dev,
                                           gchar    *firmware,
                                           gpointer  user_data,
                                           GError   *error);
 
 
+/**
+ * @brief Check the reply to a preset psk query matched configured psk
+ * @note Requires psk_flags, psk_len, and psk fields to be set
+ *
+ * @param dev
+ * @param success
+ * @param flags
+ * @param psk
+ * @param length
+ * @param user_data
+ * @param error
+ */
 void goodixtls5xx_check_preset_psk_read (FpDevice *dev,
                                          gboolean  success,
                                          guint32   flags,
@@ -90,44 +120,112 @@ void goodixtls5xx_check_preset_psk_read (FpDevice *dev,
                                          gpointer  user_data,
                                          GError   *error);
 
+/**
+ * @brief Check the reply to an idle command
+ *
+ * @param dev
+ * @param user_data
+ * @param err
+ */
 void goodixtls5xx_check_idle (FpDevice *dev,
                               gpointer  user_data,
                               GError   *err);
 
+/**
+ * @brief Check the reply to uploading an mcu config
+ *
+ * @param dev
+ * @param success
+ * @param user_data
+ * @param error
+ */
 void goodixtls5xx_check_config_upload (FpDevice *dev,
                                        gboolean  success,
                                        gpointer  user_data,
                                        GError   *error);
 
+/**
+ * @brief Check the reply to a powerdown_scan_freq command
+ *
+ * @param dev
+ * @param success
+ * @param user_data
+ * @param error
+ */
 void goodixtls5xx_check_powerdown_scan_freq (FpDevice *dev,
                                              gboolean  success,
                                              gpointer  user_data,
                                              GError   *error);
 
+/**
+ * @brief General check for GoodixNoneCallback replies
+ *
+ * @param dev
+ * @param user_data state machine to advance
+ * @param error
+ */
 void goodixtls5xx_check_none (FpDevice *dev,
                               gpointer  user_data,
                               GError   *error);
 
+/**
+ * @brief General callback for GoodixDefaultCallback replies
+ *
+ * @param dev
+ * @param data
+ * @param len
+ * @param ssm State machine to advance (userdata)
+ * @param err
+ */
 void goodixtls5xx_check_none_cmd (FpDevice *dev,
                                   guint8   *data,
                                   guint16   len,
                                   gpointer  ssm,
                                   GError   *err);
 
+/**
+ * @brief Start a scan
+ * @note This is called automatically for you unless you overwrote change_state in FpImageDeviceClass
+ *
+ * @param dev
+ */
 void goodixtls5xx_scan_start (FpiDeviceGoodixTls5xx * dev);
 
+/**
+ * @brief Decode a goodixtls frame
+ * @details Decodes the weird 4/6 byte packing: https://blog.th0m.as/misc/fingerprint-reversing/
+ * @note Doesn't decrypt it
+ *
+ * @param frame
+ * @param frame_size
+ * @param raw_frame
+ */
 void goodixtls5xx_decode_frame (GoodixTls5xxPix * frame,
                                 guint32           frame_size,
                                 const guint8     *raw_frame);
 
 
+/**
+ * @brief Initalise the TLS for the device
+ * @note You probably want to call this directly after device activation
+ *
+ * @param dev
+ */
 void goodixtls5xx_init_tls (FpDevice * dev);
 
+/**
+ * @brief Save an image to pgm
+ * @details Designed for debugging purposes, shouldn't be used in a non-debug code path
+ *
+ * @param img
+ * @param path
+ * @return gboolean
+ */
 gboolean goodixtls5xx_save_image_to_pgm (FpImage    *img,
                                          const char *path);
 
 /**
- * @brief Squashes the 12 bit pixels of a raw frame into the 4 bit pixels used
+ * @brief Squashes the 2 byte pixels of a raw frame into the 1 byte pixels used
  * by libfprint.
  * @details Borrowed from the elan driver. We reduce frames to
  * within the max and min.

--- a/libfprint/drivers/goodixtls/goodix5xx.h
+++ b/libfprint/drivers/goodixtls/goodix5xx.h
@@ -1,0 +1,67 @@
+// Goodix Tls driver for libfprint
+
+// Copyright (C) 2021 Alexander Meiler <alex.meiler@protonmail.com>
+// Copyright (C) 2021 Matthieu CHARETTE <matthieu.charette@gmail.com>
+// Copyright (C) 2021 Natasha England-Elbro <ashenglandelbro@protonmail.com>
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#pragma once
+
+#include "drivers_api.h"
+#include "goodix.h"
+
+
+G_DECLARE_DERIVABLE_TYPE (FpiDeviceGoodixTls5xx, fpi_device_goodixtls5xx, FPI, DEVICE_GOODIXTLS5XX, FpiDeviceGoodixTls);
+
+#define FPI_TYPE_DEVICE_GOODIXTLS5XX (fpi_device_goodixtls5xx_get_type ())
+
+typedef guint16 GoodixTls5xxPix;
+
+
+typedef struct
+{
+  guint16        data_len;
+  void (*free_fn)(void *);
+  const guint8 * data;
+} GoodixTls5xxMcuConfig;
+
+typedef struct
+{
+  guint16         width;
+  guint16         height;
+  unsigned char * data;
+} GoodixTls5xxImage;
+
+typedef FpImage *(*GoodixTls5xxProcessFrameFn)(GoodixTls5xxPix * pix);
+typedef GoodixTls5xxMcuConfig (*GoodixTls5xxGetMcuFn)(void);
+
+struct _FpiDeviceGoodixTls5xxClass
+{
+  FpiDeviceGoodixTlsClass    parent;
+
+  GoodixTls5xxGetMcuFn       get_mcu_cfg;
+  GoodixTls5xxProcessFrameFn process_frame;
+
+  guint16                    scan_width;
+  guint16                    scan_height;
+};
+
+
+void goodixtls5xx_scan_start (FpDevice * dev);
+
+void goodixtls5xx_decode_frame (GoodixTls5xxPix * frame,
+                                guint32           frame_size,
+                                const guint8     *raw_frame);

--- a/libfprint/drivers/goodixtls/goodix5xx.h
+++ b/libfprint/drivers/goodixtls/goodix5xx.h
@@ -45,7 +45,7 @@ typedef struct
   unsigned char * data;
 } GoodixTls5xxImage;
 
-typedef FpImage *(*GoodixTls5xxProcessFrameFn)(guint8* pix);
+typedef FpImage *(*GoodixTls5xxProcessFrameFn)(guint8 * pix);
 typedef GoodixTls5xxMcuConfig (*GoodixTls5xxGetMcuFn)(void);
 
 struct _FpiDeviceGoodixTls5xxClass
@@ -60,8 +60,12 @@ struct _FpiDeviceGoodixTls5xxClass
 };
 
 
-void goodixtls5xx_scan_start (FpDevice * dev);
+void goodixtls5xx_scan_start (FpiDeviceGoodixTls5xx * dev);
 
 void goodixtls5xx_decode_frame (GoodixTls5xxPix * frame,
                                 guint32           frame_size,
                                 const guint8     *raw_frame);
+
+
+gboolean goodixtls5xx_save_image_to_pgm (FpImage    *img,
+                                         const char *path);

--- a/libfprint/drivers/goodixtls/goodix5xx.h
+++ b/libfprint/drivers/goodixtls/goodix5xx.h
@@ -23,10 +23,10 @@
 #include "drivers_api.h"
 #include "goodix.h"
 
+#define FPI_TYPE_DEVICE_GOODIXTLS5XX (fpi_device_goodixtls5xx_get_type ())
 
 G_DECLARE_DERIVABLE_TYPE (FpiDeviceGoodixTls5xx, fpi_device_goodixtls5xx, FPI, DEVICE_GOODIXTLS5XX, FpiDeviceGoodixTls);
 
-#define FPI_TYPE_DEVICE_GOODIXTLS5XX (fpi_device_goodixtls5xx_get_type ())
 
 typedef guint16 GoodixTls5xxPix;
 
@@ -45,7 +45,7 @@ typedef struct
   unsigned char * data;
 } GoodixTls5xxImage;
 
-typedef FpImage *(*GoodixTls5xxProcessFrameFn)(GoodixTls5xxPix * pix);
+typedef FpImage *(*GoodixTls5xxProcessFrameFn)(guint8* pix);
 typedef GoodixTls5xxMcuConfig (*GoodixTls5xxGetMcuFn)(void);
 
 struct _FpiDeviceGoodixTls5xxClass

--- a/libfprint/meson.build
+++ b/libfprint/meson.build
@@ -151,7 +151,7 @@ helper_sources = {
     'aes3k' :
         [ 'drivers/aes3k.c' ],
     'goodixtls' :
-        [ 'drivers/goodixtls/goodix_proto.c', 'drivers/goodixtls/goodix.c', 'drivers/goodixtls/goodixtls.c' ],
+        [ 'drivers/goodixtls/goodix_proto.c', 'drivers/goodixtls/goodix.c', 'drivers/goodixtls/goodixtls.c', 'drivers/goodixtls/goodix5xx.c' ],
     'nss' :
         [ ],
     'udev' :


### PR DESCRIPTION
This implements a general API for (hopefully) all the goodixtls 5xxx (usb) devices. I'm making this a PR on the basis that I'd like feedback from other driver devs (I only know about 511) and get something that actually covers all the cases it needs too

## drivers to migrate
- [ ] [554b](https://github.com/TheWeirdDev/libfprint/tree/55b4-experimental) @TheWeirdDev
- [x] 511 @0x00002a

